### PR TITLE
Bump lsa_tdx_feedback to 2.0.1 and update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "image_processing", "~> 2.0"
 gem "importmap-rails"
 gem "jbuilder"
 gem "kamal", require: false
-gem 'lsa_tdx_feedback', '~> 2.0'
+gem 'lsa_tdx_feedback', '>= 2.0.1'
 gem "propshaft"
 gem "puma", ">= 5.0"
 gem "pundit"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "image_processing", "~> 2.0"
 gem "importmap-rails"
 gem "jbuilder"
 gem "kamal", require: false
-gem 'lsa_tdx_feedback', '~> 1.0'
+gem 'lsa_tdx_feedback', '~> 2.0'
 gem "propshaft"
 gem "puma", ">= 5.0"
 gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lsa_tdx_feedback (2.0.0)
+    lsa_tdx_feedback (2.0.1)
       httparty (~> 0.24.0)
       rails (>= 6.0)
       redis (>= 4.0)
@@ -555,7 +555,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener_web (~> 3.0)
-  lsa_tdx_feedback (~> 2.0)
+  lsa_tdx_feedback (>= 2.0.1)
   pg
   propshaft
   puma (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.17)
+    action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -227,17 +227,17 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lsa_tdx_feedback (1.0.4)
+    lsa_tdx_feedback (2.0.0)
       httparty (~> 0.24.0)
       rails (>= 6.0)
       redis (>= 4.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
@@ -246,11 +246,11 @@ GEM
       prism (~> 1.5)
     msgpack (1.8.1)
     multi_json (1.21.1)
-    multi_xml (0.8.1)
+    multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -364,7 +364,7 @@ GEM
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.26.4)
+    redis-client (0.30.0)
       connection_pool
     regexp_parser (2.10.0)
     reline (0.6.3)
@@ -555,7 +555,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener_web (~> 3.0)
-  lsa_tdx_feedback (~> 1.0)
+  lsa_tdx_feedback (~> 2.0)
   pg
   propshaft
   puma (>= 5.0)

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="container mx-auto px-5">
     <div class="border-t border-slate-300 mb-2"></div>
   </div>
-  <div class="container mx-auto px-5 pt-2 pb-4">
+  <div class="container mx-auto px-5 pt-2 pb-20">
     <!-- Mobile: Centered layout -->
     <div class="lg:hidden text-center text-sm">
       <div class="text-slate-700 font-semibold mb-0.5">


### PR DESCRIPTION
This pull request updates the `lsa_tdx_feedback` gem dependency in the `Gemfile` to require version 2.0.1 or higher, instead of being limited to the 1.x series. This ensures the application uses the latest features and bug fixes from the gem.
