### PR TITLE
Update LSA feedback functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "image_processing", "~> 2.0"
 gem "importmap-rails"
 gem "jbuilder"
 gem "kamal", require: false
-gem 'lsa_tdx_feedback', '>= 2.0.1'
+gem 'lsa_tdx_feedback', '>= 2.0.2'
 gem "propshaft"
 gem "puma", ">= 5.0"
 gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,7 +363,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.0)
+    rbs (4.1.1)
       logger
       prism (>= 1.6.0)
       tsort
@@ -568,7 +568,7 @@ DEPENDENCIES
   jbuilder
   kamal
   letter_opener_web (~> 3.0)
-  lsa_tdx_feedback (>= 2.0.1)
+  lsa_tdx_feedback (>= 2.0.2)
   pg
   propshaft
   puma (>= 5.0)


### PR DESCRIPTION
This pull request updates the version constraint for the `lsa_tdx_feedback` gem to ensure the project uses at least version 2.0.2. This is a minor dependency update and does not introduce any other changes.

* Updated `lsa_tdx_feedback` gem version requirement from `>= 2.0.1` to `>= 2.0.2` in the `Gemfile` to pull in the latest compatible bug fixes or features.